### PR TITLE
Add loop to clear all active incidents.

### DIFF
--- a/archiveAllIncidents.py
+++ b/archiveAllIncidents.py
@@ -65,7 +65,9 @@ def main():
     args = parse_args()
     pccToken = getPCCToken(args.pccConsole,args.apiKey,args.apiSecret)
     allActiveIncidents = getActiveIncidents(args.pccConsole,pccToken)
-    archiveIncidents(args.pccConsole,pccToken,allActiveIncidents)
+    while allActiveIncidents:
+        archiveIncidents(args.pccConsole,pccToken,allActiveIncidents)
+        allActiveIncidents = getActiveIncidents(args.pccConsole,pccToken)
 
 if __name__ == '__main__':
     sys.exit(main())


### PR DESCRIPTION
`getActiveIncidents(args.pccConsole,pccToken)` returns 50 id's at a time. A loop that terminates when this function returns an empty set should serve to clear all incidents from the platform.